### PR TITLE
Antique Atlas Markers are now automatically imported into JourneyMap

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     deobfCompile "betterwithmods:BetterWithMods:1.12-2.1.8-477"
     // Pneumaticcraft Repressurized
     deobfCompile "me.desht.pneumaticcraft:pneumaticcraft-repressurized:1.12.2-0.7.8-259"
+    // Mapping mods
     deobfCompile "antique-atlas:antiqueatlas:1.12.2:4.5.1"
     deobfCompile "journeymap:journeymap:1.12.2:5.5.4"
     deobfCompile "journeymapstages:JourneyMapStages:1.12.2:2.0.9"

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     deobfCompile "betterwithmods:BetterWithMods:1.12-2.1.8-477"
     // Pneumaticcraft Repressurized
     deobfCompile "me.desht.pneumaticcraft:pneumaticcraft-repressurized:1.12.2-0.7.8-259"
+    deobfCompile "antique-atlas:antiqueatlas:1.12.2:4.5.1"
+    deobfCompile "journeymap:journeymap:1.12.2:5.5.4"
+    deobfCompile "journeymapstages:JourneyMapStages:1.12.2:2.0.9"
 }
 
 repositories {

--- a/src/main/java/tv/darkosto/sevtweaks/SevTweaks.java
+++ b/src/main/java/tv/darkosto/sevtweaks/SevTweaks.java
@@ -11,6 +11,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import org.apache.logging.log4j.Logger;
 import tv.darkosto.sevtweaks.common.command.CommandSevTweaks;
+import tv.darkosto.sevtweaks.common.command.CommandWaypoints;
 import tv.darkosto.sevtweaks.common.compat.Compat;
 import tv.darkosto.sevtweaks.common.config.Configuration;
 import tv.darkosto.sevtweaks.common.crash.PackCrashEnhancement;
@@ -19,6 +20,7 @@ import tv.darkosto.sevtweaks.common.gamestages.GameStageScoreboard;
 import tv.darkosto.sevtweaks.common.gamestages.PNCDroneStaging;
 import tv.darkosto.sevtweaks.common.util.BiomeDebugTable;
 import tv.darkosto.sevtweaks.common.util.References;
+import tv.darkosto.sevtweaks.network.SevTweaksPacketHandler;
 
 @Mod(modid = References.modID, name = References.modName, version = References.modVersion,
         acceptedMinecraftVersions = References.mcVersion,
@@ -34,6 +36,8 @@ public class SevTweaks {
     public void preInit(FMLPreInitializationEvent event) {
         logger = event.getModLog();
         FMLCommonHandler.instance().registerCrashCallable(new PackCrashEnhancement());
+    
+        SevTweaksPacketHandler.init();
 
         Compat.compactPreInit();
         MinecraftForge.EVENT_BUS.register(CanceledEvents.class);
@@ -62,5 +66,8 @@ public class SevTweaks {
     @EventHandler
     public void onServerStart(FMLServerStartingEvent event) {
         event.registerServerCommand(new CommandSevTweaks());
+        if (Loader.isModLoaded("antiqueatlas") && Loader.isModLoaded("journeymap")) {
+            event.registerServerCommand(new CommandWaypoints());
+        }
     }
 }

--- a/src/main/java/tv/darkosto/sevtweaks/common/command/CommandWaypoints.java
+++ b/src/main/java/tv/darkosto/sevtweaks/common/command/CommandWaypoints.java
@@ -1,13 +1,17 @@
 package tv.darkosto.sevtweaks.common.command;
 
+import hunternif.mc.atlas.marker.Marker;
 import net.minecraft.command.CommandBase;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.text.TextComponentString;
 import tv.darkosto.sevtweaks.common.compat.modules.AaToJmWaypoints;
 import tv.darkosto.sevtweaks.network.MarkersSyncPacket;
 import tv.darkosto.sevtweaks.network.SevTweaksPacketHandler;
+
+import java.util.Collection;
 
 public class CommandWaypoints extends CommandBase {
     @Override
@@ -28,8 +32,15 @@ public class CommandWaypoints extends CommandBase {
     @Override
     public void execute(MinecraftServer server, ICommandSender sender, String[] args) {
         if (!(sender instanceof EntityPlayerMP)) return;
-        SevTweaksPacketHandler.INSTANCE.sendTo(new MarkersSyncPacket(
-                AaToJmWaypoints.getAaMarkers((EntityPlayer)sender)),
+        
+        Collection<Marker> markers = AaToJmWaypoints.getAaMarkers((EntityPlayer)sender);
+        
+        if (markers == null) return;
+        
+        sender.sendMessage(new TextComponentString(String.format("Importing %d markers from Antique Atlas to JourneyMap", markers.size())));
+        
+        SevTweaksPacketHandler.INSTANCE.sendTo(
+                new MarkersSyncPacket(markers),
                 (EntityPlayerMP)sender
         );
     }

--- a/src/main/java/tv/darkosto/sevtweaks/common/command/CommandWaypoints.java
+++ b/src/main/java/tv/darkosto/sevtweaks/common/command/CommandWaypoints.java
@@ -1,0 +1,36 @@
+package tv.darkosto.sevtweaks.common.command;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.MinecraftServer;
+import tv.darkosto.sevtweaks.common.compat.modules.AaToJmWaypoints;
+import tv.darkosto.sevtweaks.network.MarkersSyncPacket;
+import tv.darkosto.sevtweaks.network.SevTweaksPacketHandler;
+
+public class CommandWaypoints extends CommandBase {
+    @Override
+    public String getName() {
+        return "waypoints";
+    }
+    
+    @Override
+    public String getUsage(ICommandSender sender) {
+        return "/waypoints";
+    }
+    
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 0;
+    }
+    
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) {
+        if (!(sender instanceof EntityPlayerMP)) return;
+        SevTweaksPacketHandler.INSTANCE.sendTo(new MarkersSyncPacket(
+                AaToJmWaypoints.getAaMarkers((EntityPlayer)sender)),
+                (EntityPlayerMP)sender
+        );
+    }
+}

--- a/src/main/java/tv/darkosto/sevtweaks/common/compat/Compat.java
+++ b/src/main/java/tv/darkosto/sevtweaks/common/compat/Compat.java
@@ -23,6 +23,7 @@ public class Compat {
         compatModules.put("rustic", Rustic.class);
         compatModules.put("betterwithmods", BetterWithMods.class);
         compatModules.put("galacticraftplanets", GalacticraftPlanets.class);
+        compatModules.put("antiqueatlas", AaToJmWaypoints.class);
     }
 
     public static void compactPreInit() {

--- a/src/main/java/tv/darkosto/sevtweaks/common/compat/modules/AaToJmWaypoints.java
+++ b/src/main/java/tv/darkosto/sevtweaks/common/compat/modules/AaToJmWaypoints.java
@@ -1,0 +1,112 @@
+package tv.darkosto.sevtweaks.common.compat.modules;
+
+import hunternif.mc.atlas.api.AtlasAPI;
+import hunternif.mc.atlas.marker.DimensionMarkersData;
+import hunternif.mc.atlas.marker.Marker;
+import hunternif.mc.atlas.marker.MarkersData;
+import journeymap.client.model.Waypoint;
+import journeymap.client.waypoint.WaypointStore;
+import journeymap.common.Journeymap;
+import net.darkhax.gamestages.event.GameStageEvent;
+import net.darkhax.jmapstages.JMapStages;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Loader;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import tv.darkosto.sevtweaks.SevTweaks;
+import tv.darkosto.sevtweaks.common.compat.ICompat;
+import tv.darkosto.sevtweaks.network.MarkersSyncPacket;
+import tv.darkosto.sevtweaks.network.SevTweaksPacketHandler;
+
+import java.awt.*;
+import java.util.*;
+
+public class AaToJmWaypoints extends ICompat {
+    /**
+     * If Added Game Stage is the JMapStages waypoints stage, copy all Antique Atlas markers to JMap waypoints
+     */
+    @SubscribeEvent
+    public void gamestageEvent(GameStageEvent.Added event) {
+        if (event.getEntity().world.isRemote) {
+            return; // Shouldn't happen but protect against changes in game stages
+        }
+        if (event.getStageName().equals(JMapStages.stageWaypoint)) {
+            Collection<Marker> markers = getAaMarkers(event.getEntityPlayer());
+            
+            if (markers == null || markers.isEmpty()) {
+                return;
+            }
+    
+            SevTweaksPacketHandler.INSTANCE.sendTo(new MarkersSyncPacket(markers), (EntityPlayerMP)event.getEntityPlayer());
+        }
+    }
+    
+    /**
+     * Gather the markers from the Markers save data on the server side
+     * @param player Check this player's atlases (from inventory)
+     * @return
+     */
+    public static Collection<Marker> getAaMarkers(EntityPlayer player) {
+        if (player.world.isRemote) return null;
+        
+        // Make set to prevent duplicate markers in case player has multiple of the same atlas
+        Set<Integer> playerAtlases = new HashSet<>(AtlasAPI.getPlayerAtlases(player));
+        Collection<Marker> markers = new ArrayList<>();
+        
+        for (int atlasId : playerAtlases) {
+            MarkersData markersData = (MarkersData)player.world.loadData(MarkersData.class, String.format("aaMarkers_%d", atlasId));
+            if (markersData == null) continue;
+            Set<Integer> visitedDimensions = markersData.getVisitedDimensions();
+            
+            for (int dimension : visitedDimensions) {
+                DimensionMarkersData dimensionMarkersData = markersData.getMarkersDataInDimension(dimension);
+                Collection<Marker> markersInDimension = dimensionMarkersData.getAllMarkers();
+                markers.addAll(markersInDimension);
+            }
+        }
+        return markers;
+    }
+    
+    /**
+     * Add received markers to JMap as waypoints on the client
+     * @param markers Collection of Markers to be added to JMap
+     */
+    @SideOnly(Side.CLIENT)
+    public static void doSync(Collection<Marker> markers) {
+        SevTweaks.logger.info("{} from Antique Atlas are being imported into Journeymap", markers.size());
+        
+        Random random = new Random();
+        
+        for (Marker marker : markers) {
+            WaypointStore.INSTANCE.add(new Waypoint(
+                    marker.getLabel(),
+                    new BlockPos(marker.getX(), 70, marker.getZ()),
+                    marker.getType().equals("antiqueatlas:nether_portal") ? new Color(134, 0, 175) : new Color(random.nextFloat(), random.nextFloat(), random.nextFloat()),
+                    marker.getType().equals("antiqueatlas:tomb") ? Waypoint.Type.Death : Waypoint.Type.Normal,
+                    marker.getDimension()
+            ));
+        }
+        WaypointStore.INSTANCE.bulkSave();
+    }
+    
+    @Override
+    public void preInit() {
+        if (!Loader.isModLoaded(Journeymap.MOD_ID) || !Loader.isModLoaded("jmapstages")) return;
+        MinecraftForge.EVENT_BUS.register(this);
+        
+    }
+    
+    @Override
+    public void init() {
+    
+    }
+    
+    @Override
+    public void postInit() {
+    
+    }
+}

--- a/src/main/java/tv/darkosto/sevtweaks/common/compat/modules/AaToJmWaypoints.java
+++ b/src/main/java/tv/darkosto/sevtweaks/common/compat/modules/AaToJmWaypoints.java
@@ -77,13 +77,13 @@ public class AaToJmWaypoints extends ICompat {
      */
     @SideOnly(Side.CLIENT)
     public static void doSync(Collection<Marker> markers) {
-        SevTweaks.logger.info("{} from Antique Atlas are being imported into Journeymap", markers.size());
+        SevTweaks.logger.info("{} markers from Antique Atlas are being imported into JourneyMap", markers.size());
         
         Random random = new Random();
         
         for (Marker marker : markers) {
             WaypointStore.INSTANCE.add(new Waypoint(
-                    marker.getLabel(),
+                    marker.getLocalizedLabel(),
                     new BlockPos(marker.getX(), 70, marker.getZ()),
                     marker.getType().equals("antiqueatlas:nether_portal") ? new Color(134, 0, 175) : new Color(random.nextFloat(), random.nextFloat(), random.nextFloat()),
                     marker.getType().equals("antiqueatlas:tomb") ? Waypoint.Type.Death : Waypoint.Type.Normal,

--- a/src/main/java/tv/darkosto/sevtweaks/network/MarkersSyncPacket.java
+++ b/src/main/java/tv/darkosto/sevtweaks/network/MarkersSyncPacket.java
@@ -1,0 +1,84 @@
+package tv.darkosto.sevtweaks.network;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import hunternif.mc.atlas.marker.Marker;
+import io.netty.buffer.ByteBuf;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.fml.common.network.ByteBufUtils;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessage;
+import net.minecraftforge.fml.common.network.simpleimpl.IMessageHandler;
+import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
+import tv.darkosto.sevtweaks.common.compat.modules.AaToJmWaypoints;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class MarkersSyncPacket implements IMessage {
+    Collection<Marker> markers;
+    
+    public MarkersSyncPacket() {
+        this.markers = new ArrayList<>();
+    }
+    
+    public MarkersSyncPacket(Collection<Marker> markers) {
+        this.markers = markers;
+    }
+    
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        PacketBuffer packetBuffer = new PacketBuffer(buf);
+        
+        int typeCount = packetBuffer.readVarInt();
+        for (int i = 0; i < typeCount; i++) {
+            String typeName = ByteBufUtils.readUTF8String(packetBuffer);
+            int markerCount = packetBuffer.readVarInt();
+            for (int j = 0; j < markerCount; j++) {
+                markers.add(new Marker(j, typeName,
+                        ByteBufUtils.readUTF8String(packetBuffer), // Label
+                        packetBuffer.readVarInt(), // Dimension
+                        packetBuffer.readVarInt(), // X
+                        packetBuffer.readVarInt(), // Z
+                        true));
+            }
+        }
+    }
+    
+    @Override
+    public void toBytes(ByteBuf buf) {
+        PacketBuffer packetBuffer = new PacketBuffer(buf);
+        
+        // Sort Markers by their type
+        ListMultimap<String, Marker> markerTypeMap = ArrayListMultimap.create();
+        for (Marker marker : markers) {
+            markerTypeMap.put(marker.getType(), marker);
+        }
+        
+        // Send number of types
+        packetBuffer.writeVarInt(markerTypeMap.keySet().size());
+        
+        for (String type : markerTypeMap.keySet()) {
+            // Send type name - used to colour the waypoints in JM - and count of this type
+            ByteBufUtils.writeUTF8String(packetBuffer, type);
+            packetBuffer.writeVarInt(markerTypeMap.get(type).size());
+            for (Marker marker : markerTypeMap.get(type)) {
+                // Send Label and Coords
+                ByteBufUtils.writeUTF8String(packetBuffer, marker.getLabel());
+                packetBuffer.writeVarInt(marker.getDimension());
+                packetBuffer.writeVarInt(marker.getX());
+                packetBuffer.writeVarInt(marker.getZ());
+            }
+        }
+        
+        
+    }
+    
+    public static class MessageHandler implements IMessageHandler<MarkersSyncPacket, IMessage> {
+        @Override
+        public IMessage onMessage(MarkersSyncPacket message, MessageContext ctx) {
+            Minecraft.getMinecraft().addScheduledTask(() -> AaToJmWaypoints.doSync(message.markers));
+            return null;
+        }
+    }
+}

--- a/src/main/java/tv/darkosto/sevtweaks/network/SevTweaksPacketHandler.java
+++ b/src/main/java/tv/darkosto/sevtweaks/network/SevTweaksPacketHandler.java
@@ -1,0 +1,14 @@
+package tv.darkosto.sevtweaks.network;
+
+import net.minecraftforge.fml.common.network.NetworkRegistry;
+import net.minecraftforge.fml.common.network.simpleimpl.SimpleNetworkWrapper;
+import net.minecraftforge.fml.relauncher.Side;
+import tv.darkosto.sevtweaks.common.util.References;
+
+public class SevTweaksPacketHandler {
+    public static final SimpleNetworkWrapper INSTANCE = NetworkRegistry.INSTANCE.newSimpleChannel(References.modID);
+    
+    public static void init() {
+        INSTANCE.registerMessage(MarkersSyncPacket.MessageHandler.class, MarkersSyncPacket.class, 0, Side.CLIENT);
+    }
+}


### PR DESCRIPTION
This occurs when the JMapStages Waypoints stage is unlocked
Also adds the command `/waypoints` that can be run by any player to trigger a manual sync
